### PR TITLE
Update psf-code-of-conduct.md

### DIFF
--- a/psf-code-of-conduct.md
+++ b/psf-code-of-conduct.md
@@ -100,13 +100,13 @@ Event organizers will enforce this code throughout the event. Each event is requ
 
 ### PSF Online Spaces
 
-This Code of Conduct applies to the following people online spaces:
+This Code of Conduct applies to the following online spaces:
 
  * The [python-ideas](https://mail.python.org/mailman/listinfo/python-ideas), [core-mentorship](https://mail.python.org/mm3/mailman3/lists/core-mentorship.python.org/), [python-dev](https://mail.python.org/mailman/listinfo/python-dev), [docs](https://mail.python.org/mailman/listinfo/docs) mailing lists
  * All other [mailing lists hosted on python.org](https://mail.python.org/mailman/listinfo)
  * Python Software Foundation Zulip chat server
  * Python Software Foundation hosted Discourse server [discuss.python.org](https://discuss.python.org/)
- * Code repositories, issue trackers, and pull requests made against any Python Software Foundation controlled GitHub organization.
+ * Code repositories, issue trackers, and pull requests made against any Python Software Foundation controlled GitHub organization
  * The python.org mercurial server [hg.python.org](https://hg.python.org/)
  * Any other online space administered by the Python Software Foundation
 


### PR DESCRIPTION
1. removed "." from " * Code repositories, issue trackers, and pull requests made against any Python Software Foundation controlled GitHub organization."
2. changed "This Code of Conduct applies to the following people online spaces:" to "This Code of Conduct applies to the following online spaces:"